### PR TITLE
add lambda build script and github automation for release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,82 @@ jobs:
         run: |
           scripts/publish
 
+  release:
+    needs: [tests]
+    name: Create GitHub Release
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create_release.outputs.id }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set tag name
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            tag=v$(date +%Y%m%d.%H%M%S)
+          else
+            tag=$(basename "${{ github.ref }}")
+          fi
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          release_name: ${{ steps.tag.outputs.tag }}
+          draft: true
+          prerelease: false
+
+  build-lambda:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt install -y --no-install-recommends zip
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Run lambda build script
+        run: |
+          ./build-lambda.sh
+
+      - name: Upload Lambda Zip
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: lambda.zip
+          asset_name: lambda-python3.9.zip
+          asset_content_type: application/zip
+
+  metadata:
+    name: Publish Release
+    needs: [release, build-lambda]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_id: ${{ needs.release.outputs.release_id }}
+
   publish-docker:
     needs: [tests]
     if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ ENV/
 cdk.out/
 deployment/k8s/titiler/values-test.yaml
 docs/src/api/
+
+# lambda build
+lambda.zip
+lambda/

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+
+rm -rf ./lambda ./lambda.zip
+
+echo "installing packages..."
+pip install --upgrade pip
+
+# pin rasterio, morecantile, rio-tiler, and
+# cogeo-mosaic to fix issue with openssl initialization failing, 
+# causing 500 responses. Rasterio <1.3 seemed to be the culprit for that,
+# and rasterio 1.3 has better packages for curl, openssl, and/or gdal
+# pin markupsafe so jinja will have access to soft_unicode
+# https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044340547
+
+python -m pip install \
+  --no-cache-dir --upgrade \
+  --target=./lambda/ \
+  ./src/titiler/core \
+  ./src/titiler/extensions["cogeo,stac"] \
+  ./src/titiler/mosaic \
+  ./src/titiler/application \
+  mangum==0.17.0 \
+  rasterio==1.3.6 \
+  morecantile==3.2.5 \
+  rio-tiler==4.1.9 \
+  cogeo-mosaic==5.1.1 \
+  markupsafe==2.0.1
+
+cd lambda
+
+echo "cleaning up..."
+find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+find . -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+
+echo "copying handler..."
+cp ../deployment/aws/lambda/handler.py .
+
+echo "creating zip..."
+zip --quiet -r ../lambda.zip .
+cd -
+ls -hal ./lambda.zip


### PR DESCRIPTION
I created the lambda build shell script in the repo root since it seemed useful to offer it and make it obvious, but it can be moved elsewhere if desired.

I copied the lambda build steps and handler from the [AWS lambda build Dockerfile](https://github.com/Element84/titiler-mosaicjson/blob/main/deployment/aws/lambda/Dockerfile).  No idea if those versions need to be reviewed or updated, but I was able to deploy the zip file to the lambda and it seems to be working.

I don't know how to test the github ci workflow change, there could problems there.  I'm guessing we'll have to do the release process and see what happens.