### PR TITLE
fix lambda packaging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.12.0-1.0.0 (2023-08-15)
+
+* introduce new split versioning scheme that represents the upstream titiler version (v0.12.0) and the mosaic version (1.0.0)
+* fix broken packaging in lambda zip file introduced from upgrading to python 3.10
+
 ## 0.12.0 (2023-07-17)
 
 * use `Annotated` Type for Query/Path parameters

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 rm -rf ./lambda ./lambda.zip
 
@@ -13,7 +13,11 @@ pip install --upgrade pip
 # https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044340547
 
 python -m pip install \
-  --no-cache-dir --upgrade \
+  --no-cache-dir \
+  --platform manylinux2014_x86_64 \
+  --implementation cp \
+  --only-binary=:all: \
+  --upgrade \
   --target=./lambda/ \
   ./src/titiler/core \
   ./src/titiler/extensions["cogeo,stac"] \
@@ -29,10 +33,8 @@ python -m pip install \
 cd lambda
 
 echo "cleaning up..."
-find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+find . -type d -a -name '*.dist-info' -print0 | xargs -0 rm -rf
 find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
-find . -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 
 echo "copying handler..."
 cp ../deployment/aws/lambda/handler.py .

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 rm -rf ./lambda ./lambda.zip
 

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -35,6 +35,7 @@ cd lambda
 echo "cleaning up..."
 find . -type d -a -name '*.dist-info' -print0 | xargs -0 rm -rf
 find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+find . -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 
 echo "copying handler..."
 cp ../deployment/aws/lambda/handler.py .


### PR DESCRIPTION
- remove a step from the lambda zip cleanup that was mangling filenames
- add explicit architecture params to lambda package so running the script from an arm macbook will still work when targeting an amd64 lambda