### PR TITLE
add an optional env var config for mosaic lambda that will override t…

### DIFF
--- a/deployment/aws/lambda/handler.py
+++ b/deployment/aws/lambda/handler.py
@@ -13,6 +13,7 @@ logging.getLogger("mangum.http").setLevel(logging.ERROR)
 REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR = "REQUEST_HOST_HEADER_OVERRIDE"
 
 def handler(event, context):
+    """If env var is set, override the host header in the event passed to the lambda"""
     if rhh := os.getenv(REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR):
         event["headers"]["host"] = rhh
 

--- a/deployment/aws/lambda/handler.py
+++ b/deployment/aws/lambda/handler.py
@@ -13,8 +13,8 @@ logging.getLogger("mangum.http").setLevel(logging.ERROR)
 REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR = "REQUEST_HOST_HEADER_OVERRIDE"
 
 def handler(event, context):
-    if REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR in os.environ and os.environ[REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR] != "":
-        event["headers"]["host"] = os.environ[REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR]
+    if rhh := os.getenv(REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR):
+        event["headers"]["host"] = rhh
 
     asgi_handler = Mangum(app, lifespan="auto")
     return asgi_handler(event, context)

--- a/deployment/aws/lambda/handler.py
+++ b/deployment/aws/lambda/handler.py
@@ -1,6 +1,7 @@
 """AWS Lambda handler."""
 
 import logging
+import os
 
 from mangum import Mangum
 
@@ -9,5 +10,11 @@ from titiler.application.main import app
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
 
-# mangum > 0.11.x removes the "log_level" parameter from the Mangum constructor
-handler = Mangum(app, lifespan="auto")
+REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR = "REQUEST_HOST_HEADER_OVERRIDE"
+
+def handler(event, context):
+    if REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR in os.environ and os.environ[REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR] != "":
+        event["headers"]["host"] = os.environ[REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR]
+
+    asgi_handler = Mangum(app, lifespan="auto")
+    return asgi_handler(event, context)

--- a/deployment/aws/lambda/handler.py
+++ b/deployment/aws/lambda/handler.py
@@ -12,6 +12,7 @@ logging.getLogger("mangum.http").setLevel(logging.ERROR)
 
 REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR = "REQUEST_HOST_HEADER_OVERRIDE"
 
+
 def handler(event, context):
     """If env var is set, override the host header in the event passed to the lambda"""
     if rhh := os.getenv(REQUEST_HOST_HEADER_OVERRIDE_ENV_VAR):


### PR DESCRIPTION
…he host header in the event, so that responses crafted use the desired external-facing domain instead of internal API gateway