### PR TITLE
re-add parameters to mosaic render_tile that were previously removed inadvertently

### DIFF
--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -1034,7 +1034,6 @@ class MosaicTilerFactory(BaseTilerFactory):
                             format,
                             layer_params,
                             dataset_params,
-                            render_params,
                             colormap,
                             pixel_selection,
                             reader_params,
@@ -1164,7 +1163,6 @@ class MosaicTilerFactory(BaseTilerFactory):
             format: ImageType,
             layer_params,
             dataset_params,
-            render_params,
             colormap,
             pixel_selection: PixelSelectionMethod,
             reader_params,
@@ -1191,6 +1189,8 @@ class MosaicTilerFactory(BaseTilerFactory):
                         pixel_selection,
                         threads=threads,
                         tilesize=tilesize,
+                        **layer_params,
+                        **dataset_params,
                     )
             timings.append(("dataread", round((t.elapsed - mosaic_read) * 1000, 2)))
 

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -1034,6 +1034,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                             format,
                             layer_params,
                             dataset_params,
+                            render_params,
                             colormap,
                             pixel_selection,
                             reader_params,
@@ -1163,6 +1164,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             format: ImageType,
             layer_params,
             dataset_params,
+            render_params,
             colormap,
             pixel_selection: PixelSelectionMethod,
             reader_params,
@@ -1206,6 +1208,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     img_format=format.driver,
                     colormap=colormap,
                     **format.profile,
+                    **render_params,
                 )
             timings.append(("format", round(t.elapsed * 1000, 2)))
 


### PR DESCRIPTION
* re-add parameters to mosaic render_tile that were previously removed inadvertently. These were preventing the processing of some parameters, notably `bidx` used for multiband images.
* remove render_params, as this was always unused.