### PR TITLE
fix png colormap issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,22 +1,31 @@
 # Release Notes
 
+## Unreleased
+
+- Mosaic: For float-valued data (e.g., COP DEM), rescale before tiling.
+- Mosaic: Re-added parameters to mosaic render_tile that were previously removed inadvertently, which broke multi-band raster tiling.
+
+## 0.14.0-1.0.3 (2023-09-12)
+
+- Mosaic: Add POST and OPTIONS as CORS methods allowed
+
 ## 0.14.0-1.0.2 (2023-08-16)
 
-* updated from upstream v0.14.0
+- updated from upstream v0.14.0
 
 ## 0.12.0-1.0.1 (2023-08-16)
 
-* add boto3 package to lambda zip to satisfy use of dynamodb for mosaic
+- add boto3 package to lambda zip to satisfy use of dynamodb for mosaic
 
 ## 0.12.0-1.0.0 (2023-08-15)
 
-* introduce new split versioning scheme that represents the upstream titiler version (v0.12.0) and the mosaic version (1.0.0)
-* fix broken packaging in lambda zip file introduced from upgrading to python 3.10
+- introduce new split versioning scheme that represents the upstream titiler version (v0.12.0) and the mosaic version (1.0.0)
+- fix broken packaging in lambda zip file introduced from upgrading to python 3.10
 
 ## 0.12.0 (2023-08-03)
 
-* updated from upstream v0.12.0
+- updated from upstream v0.12.0
 
 ## 0.11.7 (2023-07-25)
 
-* updated from upstream v0.11.7
+- updated from upstream v0.11.7

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -1039,7 +1039,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                             colormap,
                             pixel_selection,
                             reader_params,
-                            rescale
+                            rescale,
                         ),
                         30,  # todo: ???
                     )
@@ -1170,7 +1170,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             colormap,
             pixel_selection: PixelSelectionMethod,
             reader_params,
-            rescale
+            rescale,
         ) -> Tuple[bytes, Any, ImageType, List[Tuple[str, float]]]:
             """Create map tile from a COG."""
             timings = []

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -1017,6 +1017,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             ),
             env=Depends(self.environment_dependency),
             reader_params=Depends(self.reader_dependency),
+            rescale=Depends(self.rescale_dependency),
         ):
             """Create map tile from a mosaic."""
 
@@ -1038,6 +1039,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                             colormap,
                             pixel_selection,
                             reader_params,
+                            rescale
                         ),
                         30,  # todo: ???
                     )
@@ -1168,6 +1170,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             colormap,
             pixel_selection: PixelSelectionMethod,
             reader_params,
+            rescale
         ) -> Tuple[bytes, Any, ImageType, List[Tuple[str, float]]]:
             """Create map tile from a COG."""
             timings = []
@@ -1200,6 +1203,9 @@ class MosaicTilerFactory(BaseTilerFactory):
             with Timer() as t:
                 image = data.post_process()
             timings.append(("postprocess", round(t.elapsed * 1000, 2)))
+
+            if rescale:
+                image.rescale(rescale)
 
             with Timer() as t:
                 content = image.render(


### PR DESCRIPTION
This was observed as an issue with COP DEM data, which is float valued and tiled using a colormap. The issue is that the data needed to be rescaled to ints before being colormapped, and that wasn't being done. This is done now.